### PR TITLE
Multiple line input and some fixes

### DIFF
--- a/fb_group.py
+++ b/fb_group.py
@@ -21,7 +21,8 @@ class FbGroup:
                 if line_count != 0:
                     user_id = row[1]
                     r = re.match(r'/ajax/hovercard/user.php\?id=(?P<user_id>\d+).*', user_id)
-                    self.ids.append(int(r.group('user_id')))
+                    if r:
+                        self.ids.append(int(r.group('user_id')))
                 line_count += 1
         return self.ids
 
@@ -38,4 +39,4 @@ class FbGroup:
         :return:
         """
         f = FFile(location)
-        f.write_file(self.get_friends_ids__string())
+        f.write_file(self.get_ids__string())

--- a/fb_group.py
+++ b/fb_group.py
@@ -1,4 +1,5 @@
 # 3d
+import codecs
 import re
 import csv
 from fbchat import Client
@@ -14,15 +15,17 @@ class FbGroup:
 
     def get_ids__list(self, location):
         self.ids = []
-        with open(location) as csv_file:
+        with codecs.open(location, "r", encoding='utf-8', errors='ignore') as csv_file:
             csv_reader = csv.reader(csv_file, delimiter=',')
             line_count = 0
             for row in csv_reader:
-                if line_count != 0:
+                if line_count != 0 and row:
                     user_id = row[1]
                     r = re.match(r'/ajax/hovercard/user.php\?id=(?P<user_id>\d+).*', user_id)
                     if r:
-                        self.ids.append(int(r.group('user_id')))
+                        f_user_id = int(r.group('user_id'))
+                        if f_user_id not in self.ids:
+                            self.ids.append(f_user_id)
                 line_count += 1
         return self.ids
 

--- a/main.py
+++ b/main.py
@@ -44,9 +44,14 @@ if __name__ == '__main__':
     if PASSWORD is None:
         PASSWORD = getpass()
     fbc = FbConnection(EMAIL, PASSWORD)
-
-    message = input("Quel message souhaitez-vous envoyé : ")
-
+    print("Quel message souhaitez-vous envoyé (Entrez / collez votre message. Entrez #fin sur la dernière ligne pour terminer):")
+    messages = []
+    while True:
+        line = input()
+        if line == '#end':
+            break
+        messages.append(line)
+    message = '\n'.join(messages)
     if sys.argv[1] == "send_group":
         send_group(fbc.client, message)
     elif sys.argv[1] == "send_friends":


### PR DESCRIPTION
 -You can enter a message with multiple lines, empty lines included, as input. To finish your message, just enter "'#end" as a last line.
 - Fix csv parsing. When regex doesn't match anything, script doesn't try to get return of matching, so error is avoided
 - Fix group export
 - Avoid to send the same message multiple times to same user